### PR TITLE
Add CPU Support

### DIFF
--- a/conf/accelerate_cpu.yaml
+++ b/conf/accelerate_cpu.yaml
@@ -1,0 +1,17 @@
+compute_environment: LOCAL_MACHINE                                                                                                                 
+debug: false                                                                                                                                       
+distributed_type: 'NO'
+downcast_bf16: 'no'
+ipex_config:
+  ipex: false
+machine_rank: 0
+main_training_function: main
+mixed_precision: 'no'
+num_machines: 1
+num_processes: 1
+rdzv_backend: static
+same_network: true
+tpu_env: []
+tpu_use_cluster: false
+tpu_use_sudo: false
+use_cpu: true

--- a/src/amplify/inference/embeddings.py
+++ b/src/amplify/inference/embeddings.py
@@ -5,10 +5,10 @@ import torch
 
 
 class Embedder:
-    def __init__(self, model, tokenizer, device=None):
+    def __init__(self, model, tokenizer, device=torch.device("cuda" if torch.cuda.is_available() else "cpu")):
         self._model = model
         self._tokenizer = tokenizer
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu") if device is None else device
+        self.device = device
 
         model.to(device)
 

--- a/src/amplify/inference/embeddings.py
+++ b/src/amplify/inference/embeddings.py
@@ -5,10 +5,10 @@ import torch
 
 
 class Embedder:
-    def __init__(self, model, tokenizer, device=torch.device("cuda:0")):
+    def __init__(self, model, tokenizer, device=None):
         self._model = model
         self._tokenizer = tokenizer
-        self.device = device
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu") if device is None else device
 
         model.to(device)
 

--- a/src/amplify/inference/human_text.py
+++ b/src/amplify/inference/human_text.py
@@ -10,6 +10,7 @@ def compare_sequences_to_out_of_sample_average(
     model=None,
     out_of_sample_sequences=None,
     target_sequences=None,
+    device='cuda',
 ):
     """
     Compare a set of sequences to the average of another set, presumably from out of sample.
@@ -19,11 +20,12 @@ def compare_sequences_to_out_of_sample_average(
       model (amplify.model.AMPLIFY): the model with which to generate embeddings.
       out_of_sample_sequences (iterable of str): sequences to average and compare against.
       target_sequences (iterable of str): sequences to compare to `out_of_sample_sequences` average.
+      device (torch.device or str): name of the device on which to compute.
 
     Returns:
         List of np.array: The respective cosine similarities, in the same order as `target_sequences`.
     """
-    embedder = Embedder(model, tokenizer)
+    embedder = Embedder(model, tokenizer, device=device)
 
     out_of_sample_embeddings = [embedder.embed(x) for x in out_of_sample_sequences]
     mean_out_of_sample_embedding = np.mean(
@@ -48,6 +50,7 @@ def compare_sequences_to_human_text(
     model=None,
     text_path=None,
     target_sequences=None,
+    device='cuda',
 ):
     """
     Wrapper call for `compare_sequences_to_out_of_sample_average`,
@@ -65,4 +68,5 @@ def compare_sequences_to_human_text(
         model=model,
         out_of_sample_sequences=out_of_sample_sequences,
         target_sequences=target_sequences,
+        device=device,
     )

--- a/src/amplify/inference/predictor.py
+++ b/src/amplify/inference/predictor.py
@@ -4,7 +4,7 @@ from .embeddings import Embedder
 
 
 class Predictor:
-    def __init__(self, model, tokenizer, device=torch.device("cuda:0")):
+    def __init__(self, model, tokenizer, device=torch.device("cuda" if torch.cuda.is_available() else "cpu")):
         """
         Bind a given model and tokenizer to a basic inference API, for simplified calls.
 

--- a/src/amplify/loss/loss.py
+++ b/src/amplify/loss/loss.py
@@ -47,9 +47,6 @@ def get_loss(
         other_special_token_ids,
     )
 
-    # Label smoothing
-    label_smoothing = label_smoothing
-
     # Class weights
     class_weights = None
     if weights is not None and any(w != 1 for w in weights.values()):

--- a/src/amplify/model/amplify.py
+++ b/src/amplify/model/amplify.py
@@ -3,10 +3,10 @@
 # From https://github.com/facebookresearch/llama/blob/main/llama/model.py
 import yaml
 
-import hydra
 import safetensors
 import torch
 from torch import nn
+from torch.nn.functional import scaled_dot_product_attention
 from xformers.ops import SwiGLU, memory_efficient_attention
 
 from .rmsnorm import RMSNorm
@@ -150,22 +150,38 @@ class EncoderBlock(nn.Module):
         xv = xv.view(batch_size, seq_len, self.config.num_attention_heads, self.d_head)
         xq, xk = apply_rotary_emb(xq, xk, freqs_cis)
 
-        attn = memory_efficient_attention(
-            query=xq,
-            key=xk,
-            value=xv,
-            attn_bias=pad_mask,
-            p=self.config.dropout_prob if self.training else 0,
-        )
-
-        _attn = None
+        # Compute the attention weight
+        attn_weights = None
         if output_attentions:
-            _attn = xq.permute(0, 2, 1, 3) @ xk.permute(0, 2, 3, 1) / (xq.size(-1) ** 0.5)
+            attn_weights = xq.permute(0, 2, 1, 3) @ xk.permute(0, 2, 3, 1) / (xq.size(-1) ** 0.5)
             if pad_mask is not None:
-                _attn = _attn + pad_mask
-            _attn = _attn.softmax(-1)
-        return self.resid_dropout(self.wo(attn.view(batch_size, seq_len, self.config.num_attention_heads * self.d_head))), _attn
+                attn_weights = attn_weights + pad_mask
+            attn_weights = attn_weights.softmax(-1)
 
+        # Compute the attention using xformers if the tensors are on GPU
+        if x.is_cuda:
+            # Input and output are of dimension (B, M, H, K) where B is the batch size, M the sequence length,
+            # H the number of heads, and K the embeding size per head
+            attn = memory_efficient_attention(
+                query=xq,
+                key=xk,
+                value=xv,
+                attn_bias=pad_mask,
+                p=self.config.dropout_prob if self.training else 0,
+            )
+        else:
+            # Input and output are of dimension (B, H, M, K)
+            attn = scaled_dot_product_attention(
+                query=xq.transpose(1, 2),
+                key=xk.transpose(1, 2),
+                value=xv.transpose(1, 2),
+                attn_mask=pad_mask,
+                dropout_p=self.config.dropout_prob if self.training else 0,
+            ).transpose(1, 2)
+
+        attn_scores = self.wo(attn.reshape(batch_size, seq_len, self.config.num_attention_heads * self.d_head))
+        return (self.resid_dropout(attn_scores), attn_weights)
+    
     def _ff_block(self, x: torch.Tensor):
         return self.ffn_dropout(self.ffn(x))
 

--- a/src/amplify/model/amplify.py
+++ b/src/amplify/model/amplify.py
@@ -254,10 +254,9 @@ class AMPLIFY(AMPLIFYPreTrainedModel):
         hidden_states, attentions = [], []
 
         # Expand and repeat: (Batch, Length) -> (Batch, Heads, Length, Length)
-        if pad_mask is not None and not torch.all(pad_mask == 0):
+        if pad_mask is not None:
+            assert pad_mask.dtype != torch.bool and 1.0 not in pad_mask, "AMPLIFY expects an additive pad_mask"
             pad_mask = pad_mask.unsqueeze(1).unsqueeze(1).repeat(1, self.config.num_attention_heads, pad_mask.size(-1), 1)
-        else:
-            pad_mask = None
 
         # RoPE
         self.freqs_cis = self.freqs_cis.to(src.device, non_blocking=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,13 +31,11 @@ def test__quickstart_example__executes_as_expected():
     as portrayed in the docs.
     """
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
     model, tokenizer = amplify.AMPLIFY.load(checkpoint_file, config_path)
-    predictor = amplify.inference.Predictor(model, tokenizer, device=device)
+    predictor = amplify.inference.Predictor(model, tokenizer)
 
     sequence = "ACGGGVWVSDDA"
-    logits = predictor.logits(sequence)
+    logits = predictor.logits(sequence).cpu()
 
     expected_logits = torch.tensor(
         [
@@ -268,7 +266,7 @@ def test__quickstart_example__executes_as_expected():
                 ],
             ]
         ]
-    ).to(device)
+    )
 
     assert (logits - expected_logits).abs().max() < 1e-4
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4195,12 +4195,18 @@ def test__compare_sequences_to_out_of_sample__executes_as_expected():
         for _ in range(target_count):
             target_sequences.append(next(reader0)[1])
 
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    else:
+        device = torch.device("cpu")
+
     model, tokenizer = amplify.AMPLIFY.load(checkpoint_file, config_path)
     easy_regex_result = amplify.inference.compare_sequences_to_out_of_sample_average(
         tokenizer=tokenizer,
         model=model,
         out_of_sample_sequences=out_of_sample_sequences,
         target_sequences=target_sequences,
+        device=device,
     )
 
     assert target_count == len(easy_regex_result)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,7 +31,7 @@ def test__quickstart_example__executes_as_expected():
     as portrayed in the docs.
     """
 
-    device = torch.device("cuda:0")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     model, tokenizer = amplify.AMPLIFY.load(checkpoint_file, config_path)
     predictor = amplify.inference.Predictor(model, tokenizer, device=device)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -24,8 +24,7 @@ reference_model, reference_tokenizer = load_model(
     reference_model_checkpoint_path, reference_model_config_path
 )
 
-device = f"cuda:{torch.cuda.current_device()}"
-
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 def test__embedder__creates_reproducible_embeddings():
     """

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -24,7 +24,6 @@ reference_model, reference_tokenizer = load_model(
     reference_model_checkpoint_path, reference_model_config_path
 )
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 def test__embedder__creates_reproducible_embeddings():
     """
@@ -47,10 +46,9 @@ def test__embedder__creates_reproducible_embeddings():
         for _ in range(datapoint_count):
             sequences.append(next(reader)[1])
 
-    model.to(device)
     embeddings = list()
 
-    embedder = Embedder(model, tokenizer, device=device)
+    embedder = Embedder(model, tokenizer)
     for sequence in sequences:
         embedding = embedder.embed(sequence)
         embeddings.append(embedding.tolist())
@@ -135,7 +133,7 @@ def test__cosine_similarities__agrees_with_values_produced_by_a_naive_implementa
 def test__dump__dumps_the_computed_embeddings_to_a_pickle(temporary_file_path):
 
     model, tokenizer = (reference_model.eval(), reference_tokenizer)
-    embedder = Embedder(model, tokenizer, device=device)
+    embedder = Embedder(model, tokenizer)
 
     sequence_file_path = os.path.join(this_dir, "example-data/easy-task-val.csv")
     with open(sequence_file_path, "r") as data_source:
@@ -169,7 +167,7 @@ def test__load__reproduces_the_results_of_self_dot_dump_given_a_filepath(
 ):
 
     model, tokenizer = (reference_model.eval(), reference_tokenizer)
-    embedder = Embedder(model, tokenizer, device=device)
+    embedder = Embedder(model, tokenizer)
 
     sequence_file_path = os.path.join(this_dir, "example-data/easy-task-val.csv")
     with open(sequence_file_path, "r") as data_source:
@@ -201,7 +199,7 @@ def test__load__reproduces_the_results_of_self_dot_dump_given_an_io_object(
 ):
 
     model, tokenizer = (reference_model.eval(), reference_tokenizer)
-    embedder = Embedder(model, tokenizer, device=device)
+    embedder = Embedder(model, tokenizer)
 
     sequence_file_path = os.path.join(this_dir, "example-data/easy-task-val.csv")
     with open(sequence_file_path, "r") as data_source:


### PR DESCRIPTION
# Summary

This pull request add support for CPU-based training and inference.

### Verification

The following checks were performed:

1. **Unit Tests**:  ran `python3 -m pytest` with all tests passing.
2. **Perplexity Evaluation**: ran `pseudo_ppl.ipynb` on CPU and GPU. The observed differences in perplexity are likely due to Flash Attention's known stability issues ([Is Flash Attention Stable?](https://arxiv.org/html/2405.02803v1)). These differences are most pronounced for longer proteins, such as `B3H5H9_ARATH`.
	- **GPU Results**:
	```csv
	>A6I415|A6I415_RAT,2.322495519944971
	>Q9NVV2|CS073_HUMAN,17.405731615848254
	>O00628|PEX7_HUMAN,2.0509484296749756
	>A0A8M9P7W8|A0A8M9P7W8_DANRE,8.219952027270358
	>A0A5G2R2Q0|A0A5G2R2Q0_PIG,2.1361886698034187
	>Q5SIM6|Q5SIM6_THET8,3.6456189770278944
	>M0RAH9|M0RAH9_RAT,1.8872439391766391
	>B3H5H9|B3H5H9_ARATH,11.666534732588502
	>F5H0U3|F5H0U3_HUMAN,2.5862320380231707
	>Q8IY34|S15A3_HUMAN,1.9109164906029565
	```
	- **CPU Results**:
	```csv
	>A6I415|A6I415_RAT,2.3576657751933143
	>Q9NVV2|CS073_HUMAN,17.405742716106037
	>O00628|PEX7_HUMAN,2.0509489355290564
	>A0A8M9P7W8|A0A8M9P7W8_DANRE,8.219951795613955
	>A0A5G2R2Q0|A0A5G2R2Q0_PIG,2.1361883295615334
	>Q5SIM6|Q5SIM6_THET8,3.645618198189389
	>M0RAH9|M0RAH9_RAT,1.9961777408179249
	>B3H5H9|B3H5H9_ARATH,14.365362470492723
	>F5H0U3|F5H0U3_HUMAN,2.586231461482032
	>Q8IY34|S15A3_HUMAN,1.8295168329427218
	```
3. **Training Test**: ran `pretrain.py` for 10 steps on CPU using the following command. Due to the significant runtime of CPU training, the loss was not compared to the baseline.
	```bash
	accelerate launch \
	--config_file=conf/accelerate_cpu.yaml \
	--num_processes=1 \
	--num_cpu_threads_per_process=32 \
	--gradient_clipping=1.0 \
	scripts/pretrain.py \
	hydra.run.dir=logs/AMPLIFY_350M \
	wandb.dir=logs/AMPLIFY_350M \
	wandb.name=AMPLIFY_350M \
	dataset=uniref100 \
	dataset.train.paths.uniref100=$SCRATCH/uniref100_train.csv \
	dataset.validation.paths.uniprot=$SCRATCH/uniprot_dev.csv \
	dataset.validation.paths.pdb=$SCRATCH/scop_dev.csv \
	dataset.validation.paths.oas=$SCRATCH/oas_dev.csv \
	trainer.dir=logs/AMPLIFY_350M \
	trainer.train.per_device_batch_size=8 \
	trainer.validation.per_device_batch_size=8 \
	trainer.gradient_accumulation_steps=1
	```