### PR TITLE
Enable Fine-Tuning on AMPLIFY model embeddings 

### DIFF
--- a/src/amplify/inference/embeddings.py
+++ b/src/amplify/inference/embeddings.py
@@ -55,7 +55,7 @@ class Embedder:
             )
 
         result = embeddings.hidden_states[-1]
-        return result[0][1:-1, :].cpu().numpy()
+        return torch.nn.functional.normalize(result[0][1:-1, :].half().cpu(), p=2, dim=1)
 
     def dump(self, sequences, out_path="embeddings.pkl", **kwargs):
         """


### PR DESCRIPTION
A typical use case is to use the embeddings as a base model and fine-tune it on dataset specific tasks. A popular approach is for example: [Light Attention](https://github.com/HannesStark/protein-localization/blob/master/models/light_attention.py)
This requires a few small modifications to the embeddings.py file.

- Normalize the embeddings using L2 normalzation (this step is the most critical!)
- Convert embeddings to HalfTensor for reduced memory and storage space requirements
- Do not convert to numpy as this operation is very slow 