### PR TITLE
Update rmsnorm.py

### DIFF
--- a/src/amplify/model/rmsnorm.py
+++ b/src/amplify/model/rmsnorm.py
@@ -20,6 +20,9 @@ class RMSNorm(nn.Module):
         self.eps = eps
         self.weight = nn.Parameter(torch.ones(dim))
 
+    def _norm(self, x):
+        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
     def forward(self, x):
         """
         Forward pass through the RMSNorm layer.
@@ -31,4 +34,5 @@ class RMSNorm(nn.Module):
             torch.Tensor: The output tensor after applying RMSNorm.
 
         """
-        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps) * self.weight
+        output = self._norm(x.float()).type_as(x) # Avoids mixed precision issues as in https://github.com/chandar-lab/AMPLIFY/issues/19
+        return output * self.weight


### PR DESCRIPTION
Modifies the forward pass of RMSNorm to avoid mixed precision issues as described in [this issue](https://github.com/chandar-lab/AMPLIFY/issues/19).

Identical modifications to those on HuggingFace.

